### PR TITLE
Fix Tests

### DIFF
--- a/test/input_output_example_test.go
+++ b/test/input_output_example_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func InputOutputExampleWithInputs(t *testing.T) {
+func TestInputOutputExampleWithInputs(t *testing.T) {
 	//
 	// Arrange
 	//
@@ -61,7 +61,7 @@ func InputOutputExampleWithInputs(t *testing.T) {
 	assert.Equal(t, inputVariable, output)
 }
 
-func InputOutputExampleWithDefaults(t *testing.T) {
+func TestInputOutputExampleWithDefaults(t *testing.T) {
 	//
 	// Arrange
 	//


### PR DESCRIPTION
Golang requires "test" to be in the test name to pick them up